### PR TITLE
Fixes to Logged-In Backend History

### DIFF
--- a/models/booking.js
+++ b/models/booking.js
@@ -26,6 +26,14 @@ const BookingSchema = new Schema({
         type:Number,
         required:true
     },
+    numOfNights:{
+        type:Number,
+        required:true
+    },
+    nightlyRate:{
+        type:Number,
+        required:true
+    },
     reservedDate:{
         type:Date,
         default: Date.now
@@ -55,6 +63,10 @@ const BookingSchema = new Schema({
         type:Number,
         default:0
     },
+    taxesAndFees:{
+        type:Number,
+        required:true
+    },
     total:{
         type:Number,
         required:true
@@ -67,8 +79,17 @@ const BookingSchema = new Schema({
         type:Number,
         default:0
     },
+    rewardDiscount:{
+        type:Number,
+        default:0
+    },
     review:{
-        type:String
+        type:String,
+        default:""
+    },
+    starReview:{
+        type:Number,
+        default:0
     }
 })
 

--- a/routes/api/bookin.js
+++ b/routes/api/bookin.js
@@ -58,7 +58,7 @@ router.get("/history", passport.authenticate("jwt", { session: false }), (req, r
                                 subtotal: element.subtotal,
                                 total: element.total,
                                 discount: element.discount,
-                                taxesAndFees: element.total - element.subtotal,
+                                taxesAndFees: element.taxesAndFees,
                                 rewardPointsUsed:element.rewardPointsUsed,
                                 rewardPointsEarned:element.rewardPointsEarned,
                                 rewardDiscount: element.rewardDiscount,
@@ -116,6 +116,13 @@ router.get("/guest-history", (req, res) => {
             historyPack.new_check_out_date = book.new_check_out_date;
             historyPack.subtotal = book.subtotal;
             historyPack.discount = book.discount;
+            historyPack.taxesAndFees = book.taxesAndFees;
+            historyPack.numOfNights = book.numOfNights;
+            
+            // Info for Review
+            historyPack.starReview = book.starReview;
+            historyPack.comment = book.review;
+
             historyPack.err = false;
 
             Hotel.findById(book.hotelID).then(hotelDoc => {

--- a/routes/api/bookin.js
+++ b/routes/api/bookin.js
@@ -24,6 +24,10 @@ router.get("/history", passport.authenticate("jwt", { session: false }), (req, r
             Booking.find({customerID: req.user.customerID}, (err, bookings) => {
                 if(err) return res.status(400).json(err);
 
+                Customer.findById(req.user.customerID, (custErr, customerInfo) => {
+                    if(custErr) return res.status(400).json(custErr);
+                
+
                     // Get the Hotel info of each of their Bookings
                     bookings.map((element, i) => { 
 
@@ -33,10 +37,13 @@ router.get("/history", passport.authenticate("jwt", { session: false }), (req, r
                             // Add the hotel details and relevant booking details as a history object
                             historyPack.push(
                             {
-                                bookingID: element._id,
+                                name: customerInfo.Firstname + " " + customerInfo.Lastname,
+                                price: hotelDoc.price[element.typeOfRoom + "Price"],
                                 hotelName: hotelDoc.name,
                                 img: hotelDoc.images[0],
                                 city: hotelDoc.city,
+
+                                bookingID: element._id,
                                 check_in_date: element.check_in_date,
                                 check_out_date: element.check_out_date,
                                 typeOfRoom: element.typeOfRoom,
@@ -45,20 +52,31 @@ router.get("/history", passport.authenticate("jwt", { session: false }), (req, r
                                 changed: element.changed,
                                 new_check_in_date: element.new_check_in_date,
                                 new_check_out_date: element.new_check_out_date,
+
+                                // Payment Info
                                 subtotal: element.subtotal,
                                 total: element.total,
                                 discount: element.discount,
+                                taxesAndFees: element.total - element.subtotal,
                                 rewardPointsUsed:element.rewardPointsUsed,
                                 rewardPointsEarned:element.rewardPointsEarned,
-                                reservedDate:element.reservedDate
+                                rewardDiscount: element.rewardDiscount,
+                                reservedDate:element.reservedDate,
+                                nightlyRate: element.numOfNights,
+
+                                // Info for Review
+                                starReview: element.starReview,
+                                comment: element.review
                             });
 
-                            // Check if we've finished packing all the history objects
-                            if (i === (bookings.length - 1)) return res.status(200).send(historyPack);
+                            // Check if we've finished packing ALL the history objects
+                            if (historyPack.length === bookings.length) return res.status(200).send(historyPack);
 
                         });
 
                     }); // end map()
+                
+                }); // end Customer.findById
 
             }); // end Booking.find
         

--- a/routes/api/bookin.js
+++ b/routes/api/bookin.js
@@ -48,6 +48,7 @@ router.get("/history", passport.authenticate("jwt", { session: false }), (req, r
                                 check_out_date: element.check_out_date,
                                 typeOfRoom: element.typeOfRoom,
                                 numOfRoom: element.numOfRoom,
+                                numOfNights: element.numOfNights,
                                 status: element.status,
                                 changed: element.changed,
                                 new_check_in_date: element.new_check_in_date,


### PR DESCRIPTION
### Made a few changes to `/api/booking/history/`
- Returns all of the Bookings for a user every time the route is called
- Also **also** now returns:
  - `taxesAndFees`
  - `name`
  - `starReview`
  - `comment`
  - `rewardDiscount`
  - `numOfNights`
