### PR TITLE
Bug fix: Fix half stars having too high of z-index

### DIFF
--- a/front_end/src/components/indiv-hotel/IndivHotel.js
+++ b/front_end/src/components/indiv-hotel/IndivHotel.js
@@ -156,6 +156,7 @@ class IndivHotel extends Component {
                       <div className="col-xl-1 col-lg-12 col-sm-12 col-12" />
                       <div className="col-xl-11 col-lg-12 col-sm-12 col-12">
                         <ReactStars
+                          className="stars"
                           count={5}
                           value={individualHotelData.star_rating}
                           size={26}
@@ -182,6 +183,7 @@ class IndivHotel extends Component {
                     <div id="hotel stars" className="row">
                       <div className="col-lg-12 col-sm-12 col-12">
                         <ReactStars
+                          className="stars"
                           count={5}
                           value={individualHotelData.star_rating}
                           size={23}
@@ -220,6 +222,7 @@ class IndivHotel extends Component {
                       </div>
 
                       <ReactStars
+                        className="stars"
                         count={5}
                         value={individualHotelData.ta_rating}
                         size={22}
@@ -237,6 +240,7 @@ class IndivHotel extends Component {
                         Hotels.com
                       </div>
                       <ReactStars
+                        className="stars"
                         count={5}
                         value={individualHotelData.hdc_rating / 2}
                         size={22}
@@ -260,6 +264,7 @@ class IndivHotel extends Component {
                       </div>
 
                       <ReactStars
+                        className="stars"
                         count={5}
                         value={individualHotelData.ta_rating}
                         size={20}
@@ -277,6 +282,7 @@ class IndivHotel extends Component {
                         Hotels.com
                       </div>
                       <ReactStars
+                        className="stars"
                         count={5}
                         value={individualHotelData.hdc_rating / 2}
                         size={20}
@@ -804,6 +810,7 @@ class IndivHotel extends Component {
                         </div>
 
                         <ReactStars
+                          className="stars"
                           count={5}
                           value={individualHotelData.ta_rating}
                           size={22}
@@ -821,6 +828,7 @@ class IndivHotel extends Component {
                           Hotels.com
                         </div>
                         <ReactStars
+                          className="stars"
                           count={5}
                           value={individualHotelData.hdc_rating / 2}
                           size={22}
@@ -1053,6 +1061,7 @@ class IndivHotel extends Component {
                       </div>
                       <small>
                           <ReactStars
+                            className="stars"
                             count={5}
                             value={ individualHotelData.review[index].reviewStar }
                             size={16}

--- a/front_end/src/components/indiv-hotel/indivHotel.css
+++ b/front_end/src/components/indiv-hotel/indivHotel.css
@@ -743,3 +743,7 @@
     font-weight: bold;
   }
 }
+
+.stars {
+  z-index: 0;
+}

--- a/front_end/src/components/searchResultOverview/FiltersWindow.js
+++ b/front_end/src/components/searchResultOverview/FiltersWindow.js
@@ -26,10 +26,7 @@ import {
 import { isWidthDown } from "@material-ui/core/withWidth";
 import {
   ExpandMore,
-  FilterList,
-  ChevronLeft,
-  ChevronRight,
-  Remove
+  FilterList
 } from "@material-ui/icons";
 import { Slider } from "@material-ui/lab";
 
@@ -42,6 +39,9 @@ let styles = theme => ({
   subtitles: { fontWeight: "bold", color: "#808080" },
   pad10: {
     padding: 10
+  },
+  stars: {
+    zIndex: 0
   }
 });
 
@@ -135,6 +135,7 @@ let FiltersWindow = props => {
                 </Grid>
                 <Grid item xs="auto">
                   <ReactStars
+                    className={classes.stars}
                     value={star_rate}
                     count={5}
                     onChange={handleStarRatings}

--- a/front_end/src/components/searchResultOverview/searchResultOverview.js
+++ b/front_end/src/components/searchResultOverview/searchResultOverview.js
@@ -59,6 +59,9 @@ let styles = theme => ({
   subtitles: { fontWeight: "bold", color: "#808080" },
   root: {
     color: "#228B22"
+  },
+  stars: {
+    zIndex: 0
   }
 });
 
@@ -467,6 +470,7 @@ class searchResultOverview extends Component {
                                   >
                                     <Grid item>
                                       <ReactStars
+                                        className={classes.stars}
                                         value={hotel.star_rates}
                                         count={5}
                                         size={32}


### PR DESCRIPTION
The bug:
Half stars in our star rating is showing up in front of dialogues.

The fix:
Apply 'z-index: 0' to all ReactStars components.

Additional stuff:
Removed some unused Material-UI icons imports.